### PR TITLE
Change text fields of Projects to markdown

### DIFF
--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
@@ -44,8 +44,8 @@
         },
         "list": {
           "label": "long_title",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "carbon_mitigation": {
@@ -86,8 +86,8 @@
         },
         "list": {
           "label": "project_goal",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "project_summary": {
@@ -100,8 +100,8 @@
         },
         "list": {
           "label": "project_summary",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "why_this_why_now": {
@@ -114,8 +114,8 @@
         },
         "list": {
           "label": "why_this_why_now",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "key_activities": {
@@ -128,8 +128,8 @@
         },
         "list": {
           "label": "key_activities",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "successes": {
@@ -142,8 +142,8 @@
         },
         "list": {
           "label": "successes",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "lesson_1": {
@@ -156,8 +156,8 @@
         },
         "list": {
           "label": "lesson_1",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "lesson_2": {
@@ -170,8 +170,8 @@
         },
         "list": {
           "label": "lesson_2",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "lesson_3": {
@@ -184,8 +184,8 @@
         },
         "list": {
           "label": "lesson_3",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_biodiversity": {
@@ -198,8 +198,8 @@
         },
         "list": {
           "label": "cb_biodiversity",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_ecosystem_services": {
@@ -212,8 +212,8 @@
         },
         "list": {
           "label": "cb_ecosystem_services",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_resilience_adapt": {
@@ -226,8 +226,8 @@
         },
         "list": {
           "label": "cb_resilience_adapt",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_health_well_being": {
@@ -240,8 +240,8 @@
         },
         "list": {
           "label": "cb_health_well_being",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_livelihood_econ": {
@@ -254,8 +254,8 @@
         },
         "list": {
           "label": "cb_livelihood_econ",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "callout": {
@@ -268,8 +268,8 @@
         },
         "list": {
           "label": "callout",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "whats_next": {
@@ -282,8 +282,8 @@
         },
         "list": {
           "label": "whats_next",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "abstract": {
@@ -296,8 +296,8 @@
         },
         "list": {
           "label": "abstract",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "citations": {
@@ -310,8 +310,8 @@
         },
         "list": {
           "label": "citations",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "graphic_1": {
@@ -629,8 +629,8 @@
         },
         "list": {
           "label": "why_this_why_now_callout",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "header_photo": {
@@ -770,8 +770,8 @@
         },
         "list": {
           "label": "video_caption",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "why_this_why_now_author": {
@@ -798,8 +798,8 @@
         },
         "list": {
           "label": "extent_credits",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "callout_author": {
@@ -876,21 +876,17 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "project_code",
-        "project_name",
-        "project_phases"
-      ],
       "edit": [
         [
           {
             "name": "project_name",
             "size": 6
-          },
+          }
+        ],
+        [
           {
             "name": "long_title",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -906,30 +902,34 @@
         [
           {
             "name": "project_goal",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "project_summary",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "key_activities",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "successes",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "lesson_1",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "lesson_1_category",
             "size": 6
@@ -938,8 +938,10 @@
         [
           {
             "name": "lesson_2",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "lesson_2_category",
             "size": 6
@@ -948,8 +950,10 @@
         [
           {
             "name": "lesson_3",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "lesson_3_category",
             "size": 6
@@ -964,47 +968,55 @@
         [
           {
             "name": "cb_ecosystem_services",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "cb_biodiversity",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "cb_resilience_adapt",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "cb_health_well_being",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "cb_livelihood_econ",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "callout",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "whats_next",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "abstract",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "citations",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -1092,11 +1104,13 @@
         [
           {
             "name": "why_this_why_now",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "why_this_why_now_callout",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -1123,10 +1137,12 @@
           {
             "name": "video",
             "size": 6
-          },
+          }
+        ],
+        [
           {
             "name": "video_caption",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -1165,14 +1181,22 @@
         ],
         [
           {
-            "name": "extent_credits",
-            "size": 6
-          },
-          {
             "name": "callout_author",
             "size": 6
           }
+        ],
+        [
+          {
+            "name": "extent_credits",
+            "size": 12
+          }
         ]
+      ],
+      "list": [
+        "id",
+        "project_code",
+        "project_name",
+        "project_phases"
       ]
     }
   },

--- a/cms/src/api/project/content-types/project/schema.json
+++ b/cms/src/api/project/content-types/project/schema.json
@@ -17,7 +17,7 @@
       "required": true
     },
     "long_title": {
-      "type": "text"
+      "type": "richtext"
     },
     "carbon_mitigation": {
       "type": "decimal"
@@ -26,55 +26,55 @@
       "type": "decimal"
     },
     "project_goal": {
-      "type": "text"
+      "type": "richtext"
     },
     "project_summary": {
-      "type": "text"
+      "type": "richtext"
     },
     "why_this_why_now": {
-      "type": "text"
+      "type": "richtext"
     },
     "key_activities": {
-      "type": "text"
+      "type": "richtext"
     },
     "successes": {
-      "type": "text"
+      "type": "richtext"
     },
     "lesson_1": {
-      "type": "text"
+      "type": "richtext"
     },
     "lesson_2": {
-      "type": "text"
+      "type": "richtext"
     },
     "lesson_3": {
-      "type": "text"
+      "type": "richtext"
     },
     "cb_biodiversity": {
-      "type": "text"
+      "type": "richtext"
     },
     "cb_ecosystem_services": {
-      "type": "text"
+      "type": "richtext"
     },
     "cb_resilience_adapt": {
-      "type": "text"
+      "type": "richtext"
     },
     "cb_health_well_being": {
-      "type": "text"
+      "type": "richtext"
     },
     "cb_livelihood_econ": {
-      "type": "text"
+      "type": "richtext"
     },
     "callout": {
-      "type": "text"
+      "type": "richtext"
     },
     "whats_next": {
-      "type": "text"
+      "type": "richtext"
     },
     "abstract": {
-      "type": "text"
+      "type": "richtext"
     },
     "citations": {
-      "type": "text"
+      "type": "richtext"
     },
     "graphic_1": {
       "type": "media",
@@ -186,7 +186,7 @@
       "type": "decimal"
     },
     "why_this_why_now_callout": {
-      "type": "text"
+      "type": "richtext"
     },
     "header_photo": {
       "type": "media",
@@ -247,13 +247,13 @@
       "type": "string"
     },
     "video_caption": {
-      "type": "text"
+      "type": "richtext"
     },
     "why_this_why_now_author": {
       "type": "string"
     },
     "extent_credits": {
-      "type": "text"
+      "type": "richtext"
     },
     "callout_author": {
       "type": "string"

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -917,26 +917,26 @@ export interface ApiProjectProject extends Schema.CollectionType {
   };
   attributes: {
     project_name: Attribute.String & Attribute.Required;
-    long_title: Attribute.Text;
+    long_title: Attribute.RichText;
     carbon_mitigation: Attribute.Decimal;
     hectares_impacted: Attribute.Decimal;
-    project_goal: Attribute.Text;
-    project_summary: Attribute.Text;
-    why_this_why_now: Attribute.Text;
-    key_activities: Attribute.Text;
-    successes: Attribute.Text;
-    lesson_1: Attribute.Text;
-    lesson_2: Attribute.Text;
-    lesson_3: Attribute.Text;
-    cb_biodiversity: Attribute.Text;
-    cb_ecosystem_services: Attribute.Text;
-    cb_resilience_adapt: Attribute.Text;
-    cb_health_well_being: Attribute.Text;
-    cb_livelihood_econ: Attribute.Text;
-    callout: Attribute.Text;
-    whats_next: Attribute.Text;
-    abstract: Attribute.Text;
-    citations: Attribute.Text;
+    project_goal: Attribute.RichText;
+    project_summary: Attribute.RichText;
+    why_this_why_now: Attribute.RichText;
+    key_activities: Attribute.RichText;
+    successes: Attribute.RichText;
+    lesson_1: Attribute.RichText;
+    lesson_2: Attribute.RichText;
+    lesson_3: Attribute.RichText;
+    cb_biodiversity: Attribute.RichText;
+    cb_ecosystem_services: Attribute.RichText;
+    cb_resilience_adapt: Attribute.RichText;
+    cb_health_well_being: Attribute.RichText;
+    cb_livelihood_econ: Attribute.RichText;
+    callout: Attribute.RichText;
+    whats_next: Attribute.RichText;
+    abstract: Attribute.RichText;
+    citations: Attribute.RichText;
     graphic_1: Attribute.Media;
     region: Attribute.Relation<
       'api::project.project',
@@ -1014,7 +1014,7 @@ export interface ApiProjectProject extends Schema.CollectionType {
     project_site_attribution: Attribute.Text;
     project_code: Attribute.String;
     people_supported: Attribute.Decimal;
-    why_this_why_now_callout: Attribute.Text;
+    why_this_why_now_callout: Attribute.RichText;
     header_photo: Attribute.Media;
     footer_photo: Attribute.Media;
     goals_photo: Attribute.Media;
@@ -1040,9 +1040,9 @@ export interface ApiProjectProject extends Schema.CollectionType {
         }
       >;
     video: Attribute.String;
-    video_caption: Attribute.Text;
+    video_caption: Attribute.RichText;
     why_this_why_now_author: Attribute.String;
-    extent_credits: Attribute.Text;
+    extent_credits: Attribute.RichText;
     callout_author: Attribute.String;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;


### PR DESCRIPTION
This PR changes main text fields type of Projects content type to richtext (markdown).

The size of markdown field in strapi admin ui is larger than text and seems like size of the field cannot be adjusted as the other fields, so the Projects form layout looks a bit different now.