### PR TITLE
[BE] Add new column for slugs to Projects

### DIFF
--- a/client/src/types/generated/strapi.schemas.ts
+++ b/client/src/types/generated/strapi.schemas.ts
@@ -498,6 +498,7 @@ export type ResourceProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -2263,6 +2264,7 @@ export type RegionProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -3993,6 +3995,7 @@ export type ProjectPhaseProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -5714,6 +5717,7 @@ export type ProjectCategoryProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -7374,6 +7378,7 @@ export interface Project {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -7976,6 +7981,7 @@ export type ProjectRegionDataAttributesProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -9734,6 +9740,7 @@ export type ProjectRequestData = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   locale?: string;
 };
 
@@ -9828,6 +9835,7 @@ export interface ProjectLocalizationRequest {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   locale: string;
 }
 
@@ -9945,6 +9953,7 @@ export type PathwayProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -11712,6 +11721,7 @@ export type LessonCategoryProjects1DataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -13466,6 +13476,7 @@ export type CountryProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -15155,6 +15166,7 @@ export type CobenefitProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -16916,6 +16928,7 @@ export type BiomeProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
@@ -18611,6 +18624,7 @@ export type ActionTypeProjectsDataItemAttributes = {
   why_this_why_now_author?: string;
   extent_credits?: string;
   callout_author?: string;
+  slug?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;

--- a/cms/config/sync/admin-role.strapi-super-admin.json
+++ b/cms/config/sync/admin-role.strapi-super-admin.json
@@ -588,7 +588,8 @@
           "video_caption",
           "why_this_why_now_author",
           "extent_credits",
-          "callout_author"
+          "callout_author",
+          "slug"
         ],
         "locales": [
           "en",
@@ -685,7 +686,8 @@
           "video_caption",
           "why_this_why_now_author",
           "extent_credits",
-          "callout_author"
+          "callout_author",
+          "slug"
         ],
         "locales": [
           "en",
@@ -756,7 +758,8 @@
           "video_caption",
           "why_this_why_now_author",
           "extent_credits",
-          "callout_author"
+          "callout_author",
+          "slug"
         ],
         "locales": [
           "en",

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
@@ -44,8 +44,8 @@
         },
         "list": {
           "label": "long_title",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "carbon_mitigation": {
@@ -86,8 +86,8 @@
         },
         "list": {
           "label": "project_goal",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "project_summary": {
@@ -100,8 +100,8 @@
         },
         "list": {
           "label": "project_summary",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "why_this_why_now": {
@@ -114,8 +114,8 @@
         },
         "list": {
           "label": "why_this_why_now",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "key_activities": {
@@ -128,8 +128,8 @@
         },
         "list": {
           "label": "key_activities",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "successes": {
@@ -142,8 +142,8 @@
         },
         "list": {
           "label": "successes",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "lesson_1": {
@@ -156,8 +156,8 @@
         },
         "list": {
           "label": "lesson_1",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "lesson_2": {
@@ -170,8 +170,8 @@
         },
         "list": {
           "label": "lesson_2",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "lesson_3": {
@@ -184,8 +184,8 @@
         },
         "list": {
           "label": "lesson_3",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_biodiversity": {
@@ -198,8 +198,8 @@
         },
         "list": {
           "label": "cb_biodiversity",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_ecosystem_services": {
@@ -212,8 +212,8 @@
         },
         "list": {
           "label": "cb_ecosystem_services",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_resilience_adapt": {
@@ -226,8 +226,8 @@
         },
         "list": {
           "label": "cb_resilience_adapt",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_health_well_being": {
@@ -240,8 +240,8 @@
         },
         "list": {
           "label": "cb_health_well_being",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "cb_livelihood_econ": {
@@ -254,8 +254,8 @@
         },
         "list": {
           "label": "cb_livelihood_econ",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "callout": {
@@ -268,8 +268,8 @@
         },
         "list": {
           "label": "callout",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "whats_next": {
@@ -282,8 +282,8 @@
         },
         "list": {
           "label": "whats_next",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "abstract": {
@@ -296,8 +296,8 @@
         },
         "list": {
           "label": "abstract",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "citations": {
@@ -310,8 +310,8 @@
         },
         "list": {
           "label": "citations",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "graphic_1": {
@@ -629,8 +629,8 @@
         },
         "list": {
           "label": "why_this_why_now_callout",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "header_photo": {
@@ -770,8 +770,8 @@
         },
         "list": {
           "label": "video_caption",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "why_this_why_now_author": {
@@ -798,8 +798,8 @@
         },
         "list": {
           "label": "extent_credits",
-          "searchable": true,
-          "sortable": true
+          "searchable": false,
+          "sortable": false
         }
       },
       "callout_author": {
@@ -812,6 +812,20 @@
         },
         "list": {
           "label": "callout_author",
+          "searchable": true,
+          "sortable": true
+        }
+      },
+      "slug": {
+        "edit": {
+          "label": "slug",
+          "description": "",
+          "placeholder": "",
+          "visible": true,
+          "editable": true
+        },
+        "list": {
+          "label": "slug",
           "searchable": true,
           "sortable": true
         }
@@ -887,10 +901,12 @@
           {
             "name": "project_name",
             "size": 6
-          },
+          }
+        ],
+        [
           {
             "name": "long_title",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -906,30 +922,34 @@
         [
           {
             "name": "project_goal",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "project_summary",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "key_activities",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "successes",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "lesson_1",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "lesson_1_category",
             "size": 6
@@ -938,8 +958,10 @@
         [
           {
             "name": "lesson_2",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "lesson_2_category",
             "size": 6
@@ -948,8 +970,10 @@
         [
           {
             "name": "lesson_3",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "lesson_3_category",
             "size": 6
@@ -964,47 +988,55 @@
         [
           {
             "name": "cb_ecosystem_services",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "cb_biodiversity",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "cb_resilience_adapt",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "cb_health_well_being",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "cb_livelihood_econ",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "callout",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "whats_next",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "abstract",
-            "size": 6
+            "size": 12
           }
         ],
         [
           {
             "name": "citations",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -1092,11 +1124,13 @@
         [
           {
             "name": "why_this_why_now",
-            "size": 6
-          },
+            "size": 12
+          }
+        ],
+        [
           {
             "name": "why_this_why_now_callout",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -1123,10 +1157,12 @@
           {
             "name": "video",
             "size": 6
-          },
+          }
+        ],
+        [
           {
             "name": "video_caption",
-            "size": 6
+            "size": 12
           }
         ],
         [
@@ -1165,11 +1201,19 @@
         ],
         [
           {
-            "name": "extent_credits",
-            "size": 6
-          },
-          {
             "name": "callout_author",
+            "size": 6
+          }
+        ],
+        [
+          {
+            "name": "extent_credits",
+            "size": 12
+          }
+        ],
+        [
+          {
+            "name": "slug",
             "size": 6
           }
         ]

--- a/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
+++ b/cms/config/sync/core-store.plugin_content_manager_configuration_content_types##api##project.project.json
@@ -890,12 +890,6 @@
       }
     },
     "layouts": {
-      "list": [
-        "id",
-        "project_code",
-        "project_name",
-        "project_phases"
-      ],
       "edit": [
         [
           {
@@ -1210,13 +1204,13 @@
             "name": "extent_credits",
             "size": 12
           }
-        ],
-        [
-          {
-            "name": "slug",
-            "size": 6
-          }
         ]
+      ],
+      "list": [
+        "id",
+        "project_code",
+        "project_name",
+        "project_phases"
       ]
     }
   },

--- a/cms/database/migrations/2024.05.03T00.00.00.add-slug-values-to-projects.js
+++ b/cms/database/migrations/2024.05.03T00.00.00.add-slug-values-to-projects.js
@@ -1,0 +1,29 @@
+module.exports = {
+  async up(knex) {
+    try {
+      const projectsToUpdate = await knex('projects')
+        .where({ locale: 'en', slug: null })
+        .select('id', 'project_name');
+
+      if (projectsToUpdate.length === 0) {
+        strapi.log.info('Projects slug values update: No projects found to update.');
+        return;
+      }
+
+      for (const project of projectsToUpdate) {
+        const slug = project.project_name.toLowerCase()
+          .replace(/ /g, '-')
+          .replace(/[^\w-]+/g, '');
+
+        await knex('projects')
+          .where({ id: project.id })
+          .update({ slug: slug });
+      }
+
+      strapi.log.info(`Projects slug values update: Updated slugs for ${projectsToUpdate.length} projects.`);
+    } catch (error) {
+      strapi.log.error('Projects slug values update: An error occurred while updating projects:', error);
+    }
+  },
+};
+

--- a/cms/src/api/project/content-types/project/lifecycles.ts
+++ b/cms/src/api/project/content-types/project/lifecycles.ts
@@ -1,0 +1,28 @@
+
+export default {
+  beforeCreate(event) {
+    const { project_name, locale } = event.params.data;
+
+    if (project_name && locale === 'en') {
+      event.params.data.slug = project_name
+        .toLowerCase()
+        .replace(/ /g, '-')
+        .replace(/[^\w-]+/g, '');
+    }
+  },
+
+  async beforeUpdate(event) {
+    const { project_name } = event.params.data;
+    const existingEntity = await strapi.entityService.findOne('api::project.project', event.params.where.id, {
+      fields: ['locale']
+    });
+    const locale = existingEntity.locale;
+
+    if (project_name && locale === 'en') {
+      event.params.data.slug = project_name
+        .toLowerCase()
+        .replace(/ /g, '-')
+        .replace(/[^\w-]+/g, '');
+    }
+  }
+}

--- a/cms/src/api/project/content-types/project/schema.json
+++ b/cms/src/api/project/content-types/project/schema.json
@@ -461,6 +461,14 @@
           "localized": true
         }
       }
+    },
+    "slug": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "string"
     }
   }
 }

--- a/cms/types/generated/contentTypes.d.ts
+++ b/cms/types/generated/contentTypes.d.ts
@@ -1358,6 +1358,12 @@ export interface ApiProjectProject extends Schema.CollectionType {
           localized: true;
         };
       }>;
+    slug: Attribute.String &
+      Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false;
+        };
+      }>;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
This PR adds new column ("slug") to the Projects collection type. Translation for this field is dis activated, meaning that all language versions of Projects will have same slug value as the default English version.

In case of creating a new project or updating the project_name of existing one - beforeCreate and beforeUpdate hooks will generate the slug value (usind same logic as FE toSlug method) and save them in database.

As for the projects that already exist in database for now it has been decided to add missing slug values manually. 
Other options could be adding a migration file (experimental feature in Strapi 4) or setting a one time cron task to fill this column for older projects automatically