### PR TITLE
add remarkGfm and rehypeRaw plugins

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -59,6 +59,7 @@
     "react-player": "2.13.0",
     "react-slick": "0.29.0",
     "recoil": "0.7.7",
+    "rehype-raw": "7.0.0",
     "remark-gfm": "4.0.0",
     "slick-carousel": "1.8.1",
     "tailwind-merge": "^1.13.2",

--- a/client/src/containers/contact/index.tsx
+++ b/client/src/containers/contact/index.tsx
@@ -7,6 +7,8 @@ import Markdown from 'react-markdown';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useLocale } from 'next-intl';
 import { useSetRecoilState } from 'recoil';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { headerStyleAtom } from '@/store';
 
@@ -109,7 +111,11 @@ const ContactPage = (): JSX.Element => {
               <h4 className="pt-20 pb-3 font-serif text-4xl font-semibold text-indigo">
                 {messages?.contact_us}
               </h4>
-              <Markdown className="prose prose-secondary text-xl font-light leading-8">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                className="prose prose-secondary text-xl font-light leading-8"
+              >
                 {messages?.contact_us_description}
               </Markdown>
 

--- a/client/src/containers/footer/index.tsx
+++ b/client/src/containers/footer/index.tsx
@@ -9,6 +9,8 @@ import { usePathname } from 'next/navigation';
 
 import { useLocale } from 'next-intl';
 import { useRecoilValue } from 'recoil';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 
@@ -59,7 +61,11 @@ const Footer: React.FC = () => {
         >
           <Wrapper className="flex w-full flex-col self-end pt-[300px] text-white xl:pt-[350px] 2xl:pt-[450px]">
             <Link className="items-left flex cursor-pointer" href={'/'} locale={locale}>
-              <Markdown className="text-2xl font-semibold uppercase">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                className="text-2xl font-semibold uppercase"
+              >
                 {messages?.main_title}
               </Markdown>
             </Link>

--- a/client/src/containers/header/index.tsx
+++ b/client/src/containers/header/index.tsx
@@ -6,6 +6,8 @@ import { usePathname } from 'next/navigation';
 
 import { useLocale } from 'next-intl';
 import { useRecoilValue } from 'recoil';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { headerStyleAtom } from '@/store';
 
@@ -42,6 +44,8 @@ const Header: React.FC = () => {
         <div className="flex items-center space-x-4">
           <Link className="flex cursor-pointer" href={'/'} locale={locale}>
             <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw]}
               className={cn({
                 'font-sans text-2xl uppercase text-white': true,
                 'text-indigo': headerStyle === 'light',

--- a/client/src/containers/home/data/index.tsx
+++ b/client/src/containers/home/data/index.tsx
@@ -1,6 +1,8 @@
 import Markdown from 'react-markdown';
 
 import { useLocale } from 'next-intl';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 import { useGetProjects } from '@/types/generated/project';
@@ -140,7 +142,11 @@ const Data = (): JSX.Element => {
                 <span className="mr-1 h-full text-xs font-normal text-text/50">*</span>
 
                 <div className="max-w-3xl">
-                  <Markdown className="prose prose-default text-xs font-normal text-text/50">
+                  <Markdown
+                    remarkPlugins={[remarkGfm]}
+                    rehypePlugins={[rehypeRaw]}
+                    className="prose prose-default text-xs font-normal text-text/50"
+                  >
                     {messages.disclaimer}
                   </Markdown>
                 </div>

--- a/client/src/containers/home/facts/index.tsx
+++ b/client/src/containers/home/facts/index.tsx
@@ -43,9 +43,13 @@ const Facts = (): JSX.Element => {
                 className="flex h-12 items-center space-x-6 px-6 text-white hover:bg-transparent hover:text-white"
                 target="_blank"
               >
-                <p className="text-base font-light uppercase">
+                <Markdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw]}
+                  className="prose prose-tertiary text-base font-light uppercase"
+                >
                   {messages.learn_more_facts_caption}
-                </p>
+                </Markdown>
                 <motion.div variants={arrowAnimation}>
                   <HiArrowNarrowRight color="white" size={20} />
                 </motion.div>

--- a/client/src/containers/home/facts/index.tsx
+++ b/client/src/containers/home/facts/index.tsx
@@ -3,6 +3,8 @@ import Markdown from 'react-markdown';
 import { motion } from 'framer-motion';
 import { useLocale } from 'next-intl';
 import { HiArrowNarrowRight } from 'react-icons/hi';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 
@@ -27,7 +29,11 @@ const Facts = (): JSX.Element => {
         {messages?.facts && (
           <div className="my-20 flex flex-col items-center space-y-4 font-sans text-white">
             <div className="max-w-4xl">
-              <Markdown className="prose prose-tertiary text-center text-xl leading-8">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                className="prose prose-tertiary text-center text-xl leading-8"
+              >
                 {messages.facts}
               </Markdown>
             </div>

--- a/client/src/containers/home/hero/index.tsx
+++ b/client/src/containers/home/hero/index.tsx
@@ -1,6 +1,8 @@
 import Markdown from 'react-markdown';
 
 import { useLocale } from 'next-intl';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 import { useGetProjects } from '@/types/generated/project';
@@ -33,12 +35,20 @@ const Hero = (): JSX.Element => {
       <Wrapper>
         <div className="mb-64 mt-44 flex flex-col items-center space-y-8 py-10 text-white">
           {!!projects?.data.data.length && messages.hero_title && (
-            <Markdown className="prose prose-tertiary font-serif text-4xl font-semibold">
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw]}
+              className="prose prose-tertiary font-serif text-4xl font-semibold"
+            >
               {`${projects.data.data.length} ${messages.hero_title}`}
             </Markdown>
           )}
           <div className="max-w-4xl">
-            <Markdown className="prose prose-tertiary text-center text-xl leading-9 text-white xl:text-2xl">
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw]}
+              className="prose prose-tertiary text-center text-xl leading-9 text-white xl:text-2xl"
+            >
               {messages?.hero_description}
             </Markdown>
           </div>

--- a/client/src/containers/home/lessons/index.tsx
+++ b/client/src/containers/home/lessons/index.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 
 import { useLocale } from 'next-intl';
 import { BsArrowRight } from 'react-icons/bs';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 
@@ -88,7 +90,11 @@ const Lessons = (): JSX.Element => {
             <h4 className="font-serif text-4xl font-semibold font-normal leading-9 text-white">
               {messages?.lessons_learned}
             </h4>
-            <Markdown className="prose prose-primary flex flex-col text-xl font-normal leading-9 text-white">
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw]}
+              className="prose prose-primary flex flex-col text-xl font-normal leading-9 text-white"
+            >
               {messages?.lessons_learned_intro}
             </Markdown>
           </Wrapper>
@@ -129,7 +135,11 @@ const Lessons = (): JSX.Element => {
                 >
                   <div className="min-w-xl flex flex-col space-y-3 p-10 text-xl leading-9 xl:p-16">
                     <div className="pb-4">
-                      <Markdown className="prose prose-primary font-serif text-2xl font-semibold">
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                        className="prose prose-primary font-serif text-2xl font-semibold"
+                      >
                         {lesson.title}
                       </Markdown>
                     </div>
@@ -141,7 +151,11 @@ const Lessons = (): JSX.Element => {
                           className="mt-0.5 fill-butternut stroke-butternut stroke-[0.4px]"
                         />
                         <div className="w-5/6">
-                          <Markdown className="prose prose-secondary font-sans text-m font-light leading-7">
+                          <Markdown
+                            remarkPlugins={[remarkGfm]}
+                            rehypePlugins={[rehypeRaw]}
+                            className="prose prose-secondary font-sans text-m font-light leading-7"
+                          >
                             {point}
                           </Markdown>
                         </div>

--- a/client/src/containers/home/map/index.tsx
+++ b/client/src/containers/home/map/index.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 
 import { useLocale } from 'next-intl';
 import { HiArrowNarrowRight } from 'react-icons/hi';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 
@@ -22,7 +24,11 @@ const HomeMap = (): JSX.Element => {
     <Wrapper>
       <section className="-mt-44 mb-12 flex h-full items-center bg-white py-12 px-16">
         <div className="flex w-1/3 flex-col">
-          <Markdown className="prose prose-secondary text-base font-light leading-7 lg:text-lg xl:text-xl xl:leading-9">
+          <Markdown
+            remarkPlugins={[remarkGfm]}
+            rehypePlugins={[rehypeRaw]}
+            className="prose prose-secondary text-base font-light leading-7 lg:text-lg xl:text-xl xl:leading-9"
+          >
             {messages?.map_description}
           </Markdown>
           {messages?.projects && (

--- a/client/src/containers/home/objectives/index.tsx
+++ b/client/src/containers/home/objectives/index.tsx
@@ -3,6 +3,8 @@ import Markdown from 'react-markdown';
 import dynamic from 'next/dynamic';
 
 import { useLocale } from 'next-intl';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 
@@ -43,13 +45,21 @@ const Objectives = (): JSX.Element => {
         <section className="flex flex-col space-y-12 py-16">
           <div className="flex flex-col space-y-4">
             {messages?.what_we_do_title && (
-              <Markdown className="prose prose-primary font-serif text-4xl font-semibold text-indigo">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                className="prose prose-primary font-serif text-4xl font-semibold text-indigo"
+              >
                 {messages.what_we_do_title}
               </Markdown>
             )}
 
             {messages?.what_we_do_description && (
-              <Markdown className="prose prose-secondary text-lg font-medium">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                className="prose prose-secondary text-lg font-medium"
+              >
                 {messages.what_we_do_description}
               </Markdown>
             )}

--- a/client/src/containers/home/pathways/index.tsx
+++ b/client/src/containers/home/pathways/index.tsx
@@ -5,6 +5,8 @@ import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { useLocale } from 'next-intl';
 import { BsArrowRight } from 'react-icons/bs';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 import { useGetPathways } from '@/types/generated/pathway';
@@ -61,10 +63,18 @@ const Pathways = (): JSX.Element => {
         {messages?.what_we_are_field_testing_title &&
           messages?.what_we_are_field_testing_description && (
             <>
-              <Markdown className="prose prose-primary font-serif text-4xl font-semibold">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                className="prose prose-primary font-serif text-4xl font-semibold"
+              >
                 {messages.what_we_are_field_testing_title}
               </Markdown>
-              <Markdown className="prose prose-secondary text-xl font-light leading-7">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                className="prose prose-secondary text-xl font-light leading-7"
+              >
                 {`${numberProjects} ${messages.what_we_are_field_testing_description}`}
               </Markdown>
             </>

--- a/client/src/containers/home/projects/index.tsx
+++ b/client/src/containers/home/projects/index.tsx
@@ -7,6 +7,8 @@ import Image from 'next/image';
 
 import { useLocale } from 'next-intl';
 import { HiChevronLeft, HiChevronRight } from 'react-icons/hi';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 import { useGetProjects } from '@/types/generated/project';
@@ -62,10 +64,18 @@ const HomeProjects = (): JSX.Element => {
       <section className="flex flex-col space-y-12 py-14">
         {messages && (
           <>
-            <Markdown className="prose prose-primary font-serif text-4xl font-semibold text-indigo">
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw]}
+              className="prose prose-primary font-serif text-4xl font-semibold text-indigo"
+            >
               {messages.prototyping_projects_title}
             </Markdown>
-            <Markdown className="prose prose-secondary text-lg font-light leading-7">
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw]}
+              className="prose prose-secondary text-lg font-light leading-7"
+            >
               {messages.prototyping_projects}
             </Markdown>
           </>
@@ -94,11 +104,19 @@ const HomeProjects = (): JSX.Element => {
 
                   <div className="to-black-0 absolute top-0 h-2/3 w-full bg-gradient-to-b from-black/50 text-white">
                     <div className="absolute top-0 flex flex-col !items-start space-y-2 px-8 py-4">
-                      <Markdown className="prose prose-tertiary font-serif text-xs font-bold uppercase">
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                        className="prose prose-tertiary font-serif text-xs font-bold uppercase"
+                      >
                         {project.attributes.project_name}
                       </Markdown>
 
-                      <Markdown className="prose prose-tertiary font-sans text-m font-light leading-5 line-clamp-6 xl:text-lg xl:leading-6">
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                        className="prose prose-tertiary font-sans text-m font-light leading-5 line-clamp-6 xl:text-lg xl:leading-6"
+                      >
                         {project.attributes.long_title}
                       </Markdown>
                     </div>

--- a/client/src/containers/projects/card/index.tsx
+++ b/client/src/containers/projects/card/index.tsx
@@ -4,6 +4,8 @@ import Markdown from 'react-markdown';
 import Image from 'next/image';
 
 import { useLocale } from 'next-intl';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 import { useGetPathways } from '@/types/generated/pathway';
@@ -82,11 +84,19 @@ const Card = ({ id, slug }: { id: number; slug: string }): JSX.Element => {
 
           <div className="flex h-[235px] flex-col justify-between bg-white p-[18px]">
             <div className="flex flex-col space-y-2">
-              <Markdown className="prose prose-primary font-serif text-2xl font-semibold line-clamp-2">
+              <Markdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                className="prose prose-primary font-serif text-2xl font-semibold line-clamp-2"
+              >
                 {data.data.data.attributes.project_name}
               </Markdown>
               <div className="h-10 max-w-xs">
-                <Markdown className="prose prose-secondary font-sans text-2xs font-light line-clamp-2">
+                <Markdown
+                  remarkPlugins={[remarkGfm]}
+                  rehypePlugins={[rehypeRaw]}
+                  className="prose prose-secondary font-sans text-2xs font-light line-clamp-2"
+                >
                   {data.data.data.attributes.long_title}
                 </Markdown>
               </div>

--- a/client/src/containers/projects/detail/index.tsx
+++ b/client/src/containers/projects/detail/index.tsx
@@ -13,6 +13,8 @@ import { BsArrowLeft } from 'react-icons/bs';
 import { HiArrowNarrowRight } from 'react-icons/hi';
 import { VscQuote } from 'react-icons/vsc';
 import { useSetRecoilState } from 'recoil';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { headerStyleAtom } from '@/store';
 
@@ -179,7 +181,11 @@ const ProjectDetail = (): JSX.Element => {
 
                   <div className="flex max-w-2xl flex-col items-center">
                     <div className="mb-16">
-                      <Markdown className="prose prose-primary font-serif text-[35px] font-medium leading-9">
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                        className="prose prose-primary font-serif text-[35px] font-medium leading-9"
+                      >
                         {data?.data?.data?.attributes.long_title}
                       </Markdown>
                     </div>
@@ -232,7 +238,11 @@ const ProjectDetail = (): JSX.Element => {
                     {messages.disclaimer && (
                       <div className="mt-8 flex w-full items-end justify-end">
                         <span className="mr-1 h-full text-xs font-normal text-text/50">*</span>
-                        <Markdown className="prose prose-default text-left text-xs font-normal text-text/50">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-default text-left text-xs font-normal text-text/50"
+                        >
                           {messages.disclaimer}
                         </Markdown>
                       </div>
@@ -245,7 +255,11 @@ const ProjectDetail = (): JSX.Element => {
                     <ExtentMap extent={data?.data?.data?.attributes.extent} />
                     {data?.data?.data?.attributes.extent_credits && (
                       <div className="absolute bottom-2 right-2 mb-1 bg-black/40 px-2">
-                        <Markdown className="prose prose-tertiary text-xs text-white">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-tertiary text-xs text-white"
+                        >
                           {data?.data?.data?.attributes.extent_credits}
                         </Markdown>
                       </div>
@@ -288,7 +302,11 @@ const ProjectDetail = (): JSX.Element => {
                       <h4 className="font-serif text-3xl font-medium xl:text-4xl">
                         {messages.goals_title}
                       </h4>
-                      <Markdown className="prose prose-tertiary text-base leading-7 xl:font-sans xl:text-lg xl:leading-8 2xl:text-xl 2xl:leading-9">
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                        className="prose prose-tertiary text-base leading-7 xl:font-sans xl:text-lg xl:leading-8 2xl:text-xl 2xl:leading-9"
+                      >
                         {data?.data?.data?.attributes.project_goal}
                       </Markdown>
                     </div>
@@ -330,7 +348,11 @@ const ProjectDetail = (): JSX.Element => {
                           >
                             <span className="text-4xl font-bold text-butternut">{idx + 1}.</span>
                             <div className="mt-2">
-                              <Markdown className="prose prose-secondary font-sans text-xl font-light">
+                              <Markdown
+                                remarkPlugins={[remarkGfm]}
+                                rehypePlugins={[rehypeRaw]}
+                                className="prose prose-secondary font-sans text-xl font-light"
+                              >
                                 {activity}
                               </Markdown>
                             </div>
@@ -355,7 +377,11 @@ const ProjectDetail = (): JSX.Element => {
                       </p>
                     )}
                     <div className="w-2/3 pt-4">
-                      <Markdown className="prose prose-secondary font-sans text-m font-light leading-7">
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                        className="prose prose-secondary font-sans text-m font-light leading-7"
+                      >
                         {data?.data?.data?.attributes.project_summary}
                       </Markdown>
                     </div>
@@ -374,7 +400,11 @@ const ProjectDetail = (): JSX.Element => {
                         {messages.why_this_why_now_title}
                       </h4>
                       <div className="max-w-3xl">
-                        <Markdown className="prose prose-tertiary text-center font-sans text-xl font-light leading-9">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-tertiary text-center font-sans text-xl font-light leading-9"
+                        >
                           {data?.data?.data?.attributes.why_this_why_now_callout}
                         </Markdown>
                       </div>
@@ -400,7 +430,11 @@ const ProjectDetail = (): JSX.Element => {
                         />
                       </div>
                       <div className="w-1/3 space-y-4 py-4">
-                        <Markdown className="prose prose-secondary text-m">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-secondary text-m"
+                        >
                           {data?.data?.data?.attributes.video_caption}
                         </Markdown>
 
@@ -454,7 +488,11 @@ const ProjectDetail = (): JSX.Element => {
                             {data?.data?.data?.attributes.lesson_1_category.data.attributes.name}
                           </td>
                           <td className="w-3/4 px-20">
-                            <Markdown className="prose prose-secondary font-sans text-m font-light leading-6">
+                            <Markdown
+                              remarkPlugins={[remarkGfm]}
+                              rehypePlugins={[rehypeRaw]}
+                              className="prose prose-secondary font-sans text-m font-light leading-6"
+                            >
                               {data?.data?.data?.attributes.lesson_1}
                             </Markdown>
                           </td>
@@ -467,7 +505,11 @@ const ProjectDetail = (): JSX.Element => {
                             {data?.data?.data?.attributes.lesson_2_category.data.attributes.name}
                           </td>
                           <td className="w-3/4 px-20">
-                            <Markdown className="prose prose-secondary font-sans text-m font-light leading-6">
+                            <Markdown
+                              remarkPlugins={[remarkGfm]}
+                              rehypePlugins={[rehypeRaw]}
+                              className="prose prose-secondary font-sans text-m font-light leading-6"
+                            >
                               {data?.data?.data?.attributes.lesson_2}
                             </Markdown>
                           </td>
@@ -480,7 +522,11 @@ const ProjectDetail = (): JSX.Element => {
                             {data?.data?.data?.attributes.lesson_3_category.data.attributes.name}
                           </td>
                           <td className="w-3/4 px-20">
-                            <Markdown className="prose prose-secondary font-sans text-m font-light leading-6">
+                            <Markdown
+                              remarkPlugins={[remarkGfm]}
+                              rehypePlugins={[rehypeRaw]}
+                              className="prose prose-secondary font-sans text-m font-light leading-6"
+                            >
                               {data?.data?.data?.attributes.lesson_3}
                             </Markdown>
                           </td>
@@ -508,7 +554,11 @@ const ProjectDetail = (): JSX.Element => {
                         <p className="font-serif text-2xl font-medium text-indigo">
                           {messages.research_summary_title}
                         </p>
-                        <Markdown className="prose prose-secondary font-sans text-m font-light leading-7">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-secondary font-sans text-m font-light leading-7"
+                        >
                           {data?.data?.data?.attributes.abstract}
                         </Markdown>
                       </div>
@@ -518,7 +568,11 @@ const ProjectDetail = (): JSX.Element => {
                         <h5 className="text-lg font-light uppercase">{messages.citations}</h5>
 
                         <div className="space-y-2">
-                          <Markdown className="prose prose-default text-2xs font-light">
+                          <Markdown
+                            remarkPlugins={[remarkGfm]}
+                            rehypePlugins={[rehypeRaw]}
+                            className="prose prose-default text-2xs font-light"
+                          >
                             {data?.data?.data?.attributes.citations}
                           </Markdown>
                         </div>
@@ -627,7 +681,11 @@ const ProjectDetail = (): JSX.Element => {
                           <p className="text-xl">{messages.ecosystem_services}</p>
                         </div>
 
-                        <Markdown className="prose prose-default text-m leading-6">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-default text-m leading-6"
+                        >
                           {data?.data?.data?.attributes.cb_ecosystem_services}
                         </Markdown>
                       </div>
@@ -644,7 +702,11 @@ const ProjectDetail = (): JSX.Element => {
                           />
                           <p className="text-xl">{messages.resilience_and_adaptation}</p>
                         </div>
-                        <Markdown className="prose prose-default text-m leading-6">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-default text-m leading-6"
+                        >
                           {data?.data?.data?.attributes.cb_resilience_adapt}
                         </Markdown>
                       </div>
@@ -661,7 +723,11 @@ const ProjectDetail = (): JSX.Element => {
                           />
                           <p className="text-xl">{messages.health_and_well_being}</p>
                         </div>
-                        <Markdown className="prose prose-default text-m leading-6">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-default text-m leading-6"
+                        >
                           {data?.data?.data?.attributes.cb_health_well_being}
                         </Markdown>
                       </div>
@@ -678,7 +744,11 @@ const ProjectDetail = (): JSX.Element => {
                           />
                           <p className="text-xl">{messages.livelihoods_and_economics}</p>
                         </div>
-                        <Markdown className="prose prose-default text-m leading-6">
+                        <Markdown
+                          remarkPlugins={[remarkGfm]}
+                          rehypePlugins={[rehypeRaw]}
+                          className="prose prose-default text-m leading-6"
+                        >
                           {data?.data?.data?.attributes.cb_livelihood_econ}
                         </Markdown>
                       </div>
@@ -691,7 +761,11 @@ const ProjectDetail = (): JSX.Element => {
                   <Wrapper className="flex flex-col items-center space-y-6 py-20">
                     <VscQuote className="fill-butternut" size={40} />
                     <div className="flex max-w-3xl flex-col items-center justify-center space-y-5 font-sans text-white">
-                      <Markdown className="prose prose-tertiary text-center text-xl font-light leading-9">
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                        className="prose prose-tertiary text-center text-xl font-light leading-9"
+                      >
                         {data?.data?.data?.attributes.callout}
                       </Markdown>
                       <p className="uppercase">{data?.data?.data?.attributes.callout_author}</p>
@@ -733,7 +807,11 @@ const ProjectDetail = (): JSX.Element => {
                       <h4 className="font-serif text-3xl font-medium text-indigo">
                         {messages.whats_next}
                       </h4>
-                      <Markdown className="prose prose-secondary font-sans text-m font-light leading-7">
+                      <Markdown
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
+                        className="prose prose-secondary font-sans text-m font-light leading-7"
+                      >
                         {data?.data?.data?.attributes.whats_next}
                       </Markdown>
                     </div>
@@ -762,10 +840,18 @@ const ProjectDetail = (): JSX.Element => {
               >
                 <Wrapper>
                   <div className="flex flex-col items-center space-y-4 py-16 font-sans text-white">
-                    <Markdown className="prose prose-tertiary pb-4 text-2xl uppercase">
+                    <Markdown
+                      remarkPlugins={[remarkGfm]}
+                      rehypePlugins={[rehypeRaw]}
+                      className="prose prose-tertiary pb-4 text-2xl uppercase"
+                    >
                       {messages?.more_information_title}
                     </Markdown>
-                    <Markdown className="prose prose-tertiary text-center text-center text-m">
+                    <Markdown
+                      remarkPlugins={[remarkGfm]}
+                      rehypePlugins={[rehypeRaw]}
+                      className="prose prose-tertiary text-center text-center text-m"
+                    >
                       {messages?.more_information}
                     </Markdown>
 

--- a/client/src/containers/projects/map-view/index.tsx
+++ b/client/src/containers/projects/map-view/index.tsx
@@ -10,6 +10,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useLocale } from 'next-intl';
 import { MapboxProps } from 'react-map-gl/dist/esm/mapbox/mapbox';
 import { useRecoilValue } from 'recoil';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetMessages } from '@/types/generated/message';
 
@@ -190,7 +192,11 @@ const MapView = ({ data }: { data }): JSX.Element => {
                   <div className="flex w-full justify-end py-3 pl-4">
                     <span className="mr-1 h-full text-xs font-normal text-text/50">*</span>
 
-                    <Markdown className="prose prose-default text-xs font-normal text-text/50">
+                    <Markdown
+                      remarkPlugins={[remarkGfm]}
+                      rehypePlugins={[rehypeRaw]}
+                      className="prose prose-default text-xs font-normal text-text/50"
+                    >
                       {messages.disclaimer}
                     </Markdown>
                   </div>

--- a/client/src/containers/projects/metrics-view/index.tsx
+++ b/client/src/containers/projects/metrics-view/index.tsx
@@ -7,6 +7,8 @@ import Image from 'next/image';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useLocale } from 'next-intl';
 import { HiChevronDown, HiChevronUp } from 'react-icons/hi';
+import rehypeRaw from 'rehype-raw';
+import remarkGfm from 'remark-gfm';
 
 import { useGetCobenefits } from '@/types/generated/cobenefit';
 import { useGetMessages } from '@/types/generated/message';
@@ -229,12 +231,20 @@ const MetricsView = ({ data }: { data }): JSX.Element => {
 
                           <div className="flex w-[100px] flex-col xl:w-auto">
                             <div className="-mt-1">
-                              <Markdown className="prose prose-primary font-serif text-lg font-semibold leading-6 group-hover:underline xl:text-2xl xl:leading-7">
+                              <Markdown
+                                remarkPlugins={[remarkGfm]}
+                                rehypePlugins={[rehypeRaw]}
+                                className="prose prose-primary font-serif text-lg font-semibold leading-6 group-hover:underline xl:text-2xl xl:leading-7"
+                              >
                                 {project.attributes.project_name}
                               </Markdown>
                             </div>
 
-                            <Markdown className="prose prose-secondary overflow-hidden text-2xs leading-4 line-clamp-3 group-hover:opacity-80">
+                            <Markdown
+                              remarkPlugins={[remarkGfm]}
+                              rehypePlugins={[rehypeRaw]}
+                              className="prose prose-secondary overflow-hidden text-2xs leading-4 line-clamp-3 group-hover:opacity-80"
+                            >
                               {project.attributes.long_title}
                             </Markdown>
                           </div>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -80,18 +80,21 @@ module.exports = {
           css: {
             '--tw-prose-links': theme('colors.blue[600]'),
             '--tw-prose-body': theme('colors.indigo'),
+            '--tw-prose-bold': theme('colors.indigo'),
           },
         },
         secondary: {
           css: {
             '--tw-prose-links': theme('colors.blue[600]'),
             '--tw-prose-body': theme('colors.text'),
+            '--tw-prose-bold': theme('colors.text'),
           },
         },
         tertiary: {
           css: {
             '--tw-prose-links': theme('colors.blue[600]'),
             '--tw-prose-body': theme('colors.white'),
+            '--tw-prose-bold': theme('colors.white'),
           },
         },
       }),

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3989,7 +3989,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0":
+"entities@npm:^4.2.0, entities@npm:^4.4.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 853f8ebd5b425d350bffa97dd6958143179a5938352ccae092c62d1267c4e392a039be1bae7d51b6e4ffad25f51f9617531fedf5237f15df302ccfb452cbf2d7
@@ -5719,6 +5719,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-from-parse5@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "hast-util-from-parse5@npm:8.0.1"
+  dependencies:
+    "@types/hast": ^3.0.0
+    "@types/unist": ^3.0.0
+    devlop: ^1.0.0
+    hastscript: ^8.0.0
+    property-information: ^6.0.0
+    vfile: ^6.0.0
+    vfile-location: ^5.0.0
+    web-namespaces: ^2.0.0
+  checksum: fdd1ab8b03af13778ecb94ef9a58b1e3528410cdfceb3d6bb7600508967d0d836b451bc7bc3baf66efb7c730d3d395eea4bb1b30352b0162823d9f0de976774b
+  languageName: node
+  linkType: hard
+
+"hast-util-parse-selector@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "hast-util-parse-selector@npm:4.0.0"
+  dependencies:
+    "@types/hast": ^3.0.0
+  checksum: 76087670d3b0b50b23a6cb70bca53a6176d6608307ccdbb3ed18b650b82e7c3513bfc40348f1389dc0c5ae872b9a768851f4335f44654abd7deafd6974c52402
+  languageName: node
+  linkType: hard
+
+"hast-util-raw@npm:^9.0.0":
+  version: 9.0.3
+  resolution: "hast-util-raw@npm:9.0.3"
+  dependencies:
+    "@types/hast": ^3.0.0
+    "@types/unist": ^3.0.0
+    "@ungap/structured-clone": ^1.0.0
+    hast-util-from-parse5: ^8.0.0
+    hast-util-to-parse5: ^8.0.0
+    html-void-elements: ^3.0.0
+    mdast-util-to-hast: ^13.0.0
+    parse5: ^7.0.0
+    unist-util-position: ^5.0.0
+    unist-util-visit: ^5.0.0
+    vfile: ^6.0.0
+    web-namespaces: ^2.0.0
+    zwitch: ^2.0.0
+  checksum: 99061946777fa0d8fade8ce5511195c41fd49d2b7dc253d7f8590764d2e7ea6a0af90f1355a20940d8ad395c74b138b42686adfc5d9deb01bfd67f6641d835ae
+  languageName: node
+  linkType: hard
+
 "hast-util-to-estree@npm:^2.0.0":
   version: 2.3.3
   resolution: "hast-util-to-estree@npm:2.3.3"
@@ -5765,6 +5811,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hast-util-to-parse5@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "hast-util-to-parse5@npm:8.0.0"
+  dependencies:
+    "@types/hast": ^3.0.0
+    comma-separated-tokens: ^2.0.0
+    devlop: ^1.0.0
+    property-information: ^6.0.0
+    space-separated-tokens: ^2.0.0
+    web-namespaces: ^2.0.0
+    zwitch: ^2.0.0
+  checksum: 137469209cb2b32b57387928878dc85310fbd5afa4807a8da69529199bb1d19044bfc95b50c3dc68d4fb2b6cb8bf99b899285597ab6ab318f50422eefd5599dd
+  languageName: node
+  linkType: hard
+
 "hast-util-whitespace@npm:^2.0.0":
   version: 2.0.1
   resolution: "hast-util-whitespace@npm:2.0.1"
@@ -5778,6 +5839,19 @@ __metadata:
   dependencies:
     "@types/hast": ^3.0.0
   checksum: 41d93ccce218ba935dc3c12acdf586193c35069489c8c8f50c2aa824c00dec94a3c78b03d1db40fa75381942a189161922e4b7bca700b3a2cc779634c351a1e4
+  languageName: node
+  linkType: hard
+
+"hastscript@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "hastscript@npm:8.0.0"
+  dependencies:
+    "@types/hast": ^3.0.0
+    comma-separated-tokens: ^2.0.0
+    hast-util-parse-selector: ^4.0.0
+    property-information: ^6.0.0
+    space-separated-tokens: ^2.0.0
+  checksum: ae3c20223e7b847320c0f98b6fb3c763ebe1bf3913c5805fbc176cf84553a9db1117ca34cf842a5235890b4b9ae0e94501bfdc9a9b870a5dbf5fc52426db1097
   languageName: node
   linkType: hard
 
@@ -5811,6 +5885,13 @@ __metadata:
   version: 3.0.0
   resolution: "html-url-attributes@npm:3.0.0"
   checksum: 9f499d33e6ddff6c2d2766fd73d2f22f3c370b4e485a92b0b2938303665b306dc7f36b2724c9466764e8f702351c01f342f5ec933be41a31c1fa40b72087b91d
+  languageName: node
+  linkType: hard
+
+"html-void-elements@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "html-void-elements@npm:3.0.0"
+  checksum: 59be397525465a7489028afa064c55763d9cccd1d7d9f630cca47137317f0e897a9ca26cef7e745e7cff1abc44260cfa407742b243a54261dfacd42230e94fce
   languageName: node
   linkType: hard
 
@@ -8627,6 +8708,7 @@ __metadata:
     react-player: 2.13.0
     react-slick: 0.29.0
     recoil: 0.7.7
+    rehype-raw: 7.0.0
     remark-gfm: 4.0.0
     slick-carousel: 1.8.1
     start-server-and-test: 1.12.1
@@ -9243,6 +9325,15 @@ __metadata:
     is-decimal: ^2.0.0
     is-hexadecimal: ^2.0.0
   checksum: 32a6ff5b9acb9d2c4d71537308521fd265e685b9215691df73feedd9edfe041bb6da9f89bd0c35c4a2bc7d58e3e76e399bb6078c2fd7d2a343ff1dd46edbf1bd
+  languageName: node
+  linkType: hard
+
+"parse5@npm:^7.0.0":
+  version: 7.1.2
+  resolution: "parse5@npm:7.1.2"
+  dependencies:
+    entities: ^4.4.0
+  checksum: 59465dd05eb4c5ec87b76173d1c596e152a10e290b7abcda1aecf0f33be49646ea74840c69af975d7887543ea45564801736356c568d6b5e71792fd0f4055713
   languageName: node
   linkType: hard
 
@@ -10140,6 +10231,17 @@ __metadata:
   version: 3.2.0
   resolution: "regexpp@npm:3.2.0"
   checksum: a78dc5c7158ad9ddcfe01aa9144f46e192ddbfa7b263895a70a5c6c73edd9ce85faf7c0430e59ac38839e1734e275b9c3de5c57ee3ab6edc0e0b1bdebefccef8
+  languageName: node
+  linkType: hard
+
+"rehype-raw@npm:7.0.0":
+  version: 7.0.0
+  resolution: "rehype-raw@npm:7.0.0"
+  dependencies:
+    "@types/hast": ^3.0.0
+    hast-util-raw: ^9.0.0
+    vfile: ^6.0.0
+  checksum: f9e28dcbf4c6c7d91a97c10a840310f18ef3268aa45abb3e0428b6b191ff3c4fa8f753b910d768588a2dac5c7da7e557b4ddc3f1b6cd252e8d20cb62d60c65ed
   languageName: node
   linkType: hard
 
@@ -12098,6 +12200,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vfile-location@npm:^5.0.0":
+  version: 5.0.2
+  resolution: "vfile-location@npm:5.0.2"
+  dependencies:
+    "@types/unist": ^3.0.0
+    vfile: ^6.0.0
+  checksum: b61c048cedad3555b4f007f390412c6503f58a6a130b58badf4ee340c87e0d7421e9c86bbc1494c57dedfccadb60f5176cc60ba3098209d99fb3a3d8804e4c38
+  languageName: node
+  linkType: hard
+
 "vfile-message@npm:^3.0.0":
   version: 3.1.4
   resolution: "vfile-message@npm:3.1.4"
@@ -12183,6 +12295,13 @@ __metadata:
   dependencies:
     defaults: ^1.0.3
   checksum: 814e9d1ddcc9798f7377ffa448a5a3892232b9275ebb30a41b529607691c0491de47cba426e917a4d08ded3ee7e9ba2f3fe32e62ee3cd9c7d3bafb7754bd553c
+  languageName: node
+  linkType: hard
+
+"web-namespaces@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "web-namespaces@npm:2.0.1"
+  checksum: b6d9f02f1a43d0ef0848a812d89c83801d5bbad57d8bb61f02eb6d7eb794c3736f6cc2e1191664bb26136594c8218ac609f4069722c6f56d9fc2d808fa9271c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add remarkGfm and rehypeRaw plugins to enable strikethrough and underline on Markdown.