### PR TITLE
add long labels to language switcher and add three more languages [NCSPD-89][NCSPD-95]

### DIFF
--- a/client/src/containers/header/index.tsx
+++ b/client/src/containers/header/index.tsx
@@ -33,7 +33,7 @@ const Header: React.FC = () => {
   return (
     <div
       className={cn({
-        'fixed z-50 w-full': true,
+        'fixed z-[60] w-full': true,
         'border-b bg-white': headerStyle === 'light',
         'top-0 w-full': !pathname.startsWith('/projects'),
         'bg-gradient-to-r from-midnight to-indigo':
@@ -64,7 +64,7 @@ const Header: React.FC = () => {
             <p>BETA</p>
           </div>
         </div>
-        <div className="relative flex items-center pr-20">
+        <div className="relative flex items-center pr-32">
           <NavigationTabs />
           <div className="absolute top-4 right-0">
             <LanguageSwitcher />

--- a/client/src/containers/language-switcher/index.tsx
+++ b/client/src/containers/language-switcher/index.tsx
@@ -29,19 +29,29 @@ const LanguageSwitcher: React.FC = () => {
 
   useOnClickOutside(ref, handleClickOutside);
 
+  const LOCALE_LABELS = {
+    en: 'English',
+    es: 'Spanish',
+    pt: 'Portuguese',
+    id: 'Indonesian',
+    fr: 'French',
+    cmn: 'Mandarin',
+    sw: 'Swahili',
+  };
+
   return (
     <div
       ref={ref}
       className={cn({
-        'w-16 rounded-lg border bg-transparent text-white': true,
+        'w-28 rounded-lg border bg-transparent text-white': true,
         'bg-white text-indigo': headerStyle === 'light' || (headerStyle === 'dark' && openSwitcher),
       })}
     >
       <button
-        className="flex h-9 w-full items-center justify-between space-x-2 px-2 uppercase"
+        className="flex h-9 w-full items-center justify-between space-x-2 px-2"
         onClick={handleSwitcher}
       >
-        <p>{selectedLocale}</p>
+        <p>{LOCALE_LABELS[selectedLocale]}</p>
         {!openSwitcher && <MdArrowDropDown className="h-6 w-6" />}
         {openSwitcher && <MdArrowDropUp className="h-6 w-6" />}
       </button>
@@ -54,12 +64,12 @@ const LanguageSwitcher: React.FC = () => {
               <li
                 key={locale}
                 className={cn({
-                  'flex h-9 w-full flex-col justify-center px-2 uppercase last:rounded-b-lg': true,
+                  'flex h-9 w-full flex-col justify-center px-2 last:rounded-b-lg': true,
                   'hover:bg-gray-100': headerStyle === 'light' || headerStyle === 'dark',
                 })}
               >
                 <Link href={pathname} locale={locale}>
-                  {locale}
+                  {LOCALE_LABELS[locale]}
                 </Link>
               </li>
             ))}

--- a/client/src/middleware.ts
+++ b/client/src/middleware.ts
@@ -6,7 +6,7 @@ export default async function middleware(request: NextRequest) {
   const defaultLocale = request.headers.get('x-your-custom-locale') || 'en';
 
   const handleI18nRouting = createIntlMiddleware({
-    locales: ['en', 'es', 'pt', 'id'],
+    locales: ['en', 'es', 'pt', 'id', 'fr', 'cmn', 'sw'],
     defaultLocale,
   });
   const response = handleI18nRouting(request);

--- a/client/src/navigation.ts
+++ b/client/src/navigation.ts
@@ -1,6 +1,6 @@
 import { createSharedPathnamesNavigation } from 'next-intl/navigation';
 
-export const locales = ['en', 'es', 'pt', 'id'];
+export const locales = ['en', 'es', 'pt', 'id', 'fr', 'cmn', 'sw'];
 
 const localePrefix = 'always';
 


### PR DESCRIPTION
- [ ] Add French, Madarin, Swahili to the language switcher: 
[NCSPD-95](https://vizzuality.atlassian.net/browse/NCSPD-95)

- [ ] Spell out languages instead of using abbreviations in dropdown box 
[NCSPD-89](https://vizzuality.atlassian.net/browse/NCSPD-89)